### PR TITLE
Add ability to terminate TLS at the edge

### DIFF
--- a/api/v1/stroomcluster_extra.go
+++ b/api/v1/stroomcluster_extra.go
@@ -8,6 +8,8 @@ const (
 )
 
 type HttpsSettings struct {
+	// Boolean value controling if TLS is enabled within the cluster
+	Enabled bool `json:"enabled"`
 	// Name of the TLS secret containing the items `keystore.p12` and `truststore.p12`
 	TlsSecretName string `json:"tlsSecretName"`
 	// Password of the keystore and truststore

--- a/config/crd/bases/stroom.gchq.github.io_stroomclusters.yaml
+++ b/config/crd/bases/stroom.gchq.github.io_stroomclusters.yaml
@@ -1904,6 +1904,10 @@ spec:
               https:
                 description: HTTPS settings
                 properties:
+                  enabled:
+                    description: Boolean value controling if TLS is enabled within
+                      the cluster
+                    type: boolean
                   tlsKeystorePasswordSecret:
                     description: Password of the keystore and truststore
                     properties:
@@ -1920,6 +1924,7 @@ spec:
                       and `truststore.p12`
                     type: string
                 required:
+                - enabled
                 - tlsKeystorePasswordSecret
                 - tlsSecretName
                 type: object

--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -3290,6 +3290,9 @@ spec:
               https:
                 description: HTTPS settings
                 properties:
+                  enabled:
+                    description: Boolean value controling if TLS is enabled within the cluster
+                    type: boolean
                   tlsKeystorePasswordSecret:
                     description: Password of the keystore and truststore
                     properties:
@@ -3305,6 +3308,7 @@ spec:
                     description: Name of the TLS secret containing the items `keystore.p12` and `truststore.p12`
                     type: string
                 required:
+                - enabled
                 - tlsKeystorePasswordSecret
                 - tlsSecretName
                 type: object


### PR DESCRIPTION
#11 Create the ability to run Stroom without TLS internal to the cluster. This allows for TLS termination to happen at the edge of the cluster. 