### PR TITLE
Add ImplementationSpecific option to ingress

### DIFF
--- a/api/v1/stroomcluster_extra.go
+++ b/api/v1/stroomcluster_extra.go
@@ -23,6 +23,8 @@ type IngressSettings struct {
 	SecretName string `json:"secretName"`
 	// Ingress class name (e.g. nginx)
 	ClassName string `json:"className,omitempty"`
+	// Override path type for all ingress resources as `ImplementationSpecific`
+	PathTypeOverride bool `json:"pathTypeOverride,omitempty"`
 }
 
 type OpenIdConfiguration struct {

--- a/config/crd/bases/stroom.gchq.github.io_stroomclusters.yaml
+++ b/config/crd/bases/stroom.gchq.github.io_stroomclusters.yaml
@@ -1951,6 +1951,9 @@ spec:
                     description: DNS name at which the application will be reached
                       (e.g. stroom.example.com)
                     type: string
+                  pathTypeOverride:
+                    description: Override path type for all ingress resources as `ImplementationSpecific`
+                    type: boolean
                   secretName:
                     description: Name of the TLS `Secret` containing the private key
                       and server certificate for the `Ingress`

--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -3333,6 +3333,9 @@ spec:
                   hostName:
                     description: DNS name at which the application will be reached (e.g. stroom.example.com)
                     type: string
+                  pathTypeOverride:
+                    description: Override path type for all ingress resources as `ImplementationSpecific`
+                    type: boolean
                   secretName:
                     description: Name of the TLS `Secret` containing the private key and server certificate for the `Ingress`
                     type: string


### PR DESCRIPTION
#2 Created a new config option `pathTypeOverride` that sets ingress path to [ImplementationSpecific](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types) which allows the IngressClass to decide the pathType. 