### PR TITLE
Add custom ingress labelling and haproxy config

### DIFF
--- a/api/v1/stroomcluster_nodeset.go
+++ b/api/v1/stroomcluster_nodeset.go
@@ -33,6 +33,9 @@ type NodeSet struct {
 	// IngressAnnotations is an optional map of annotations to apply to the NodeSet's Ingress. These override any
 	// default annotations provided by the controller.
 	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`
+	// IngressLabels is an optional map of labels to apply to the NodeSet's Ingress. These take precedence over any
+	// controller provided labels.
+	IngressLabels map[string]string `json:"ingressLabels,omitempty"`
 	// StartupProbeTimings specify parameters for initial Pod startup. These should be set according to how long a node
 	// typically takes to start up and respond to healthchecks.
 	StartupProbeTimings ProbeTimings `json:"startupProbeTimings,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -376,6 +376,13 @@ func (in *NodeSet) DeepCopyInto(out *NodeSet) {
 			(*out)[key] = val
 		}
 	}
+	if in.IngressLabels != nil {
+		in, out := &in.IngressLabels, &out.IngressLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	out.StartupProbeTimings = in.StartupProbeTimings
 	out.ReadinessProbeTimings = in.ReadinessProbeTimings
 	out.LivenessProbeTimings = in.LivenessProbeTimings

--- a/config/crd/bases/stroom.gchq.github.io_stroomclusters.yaml
+++ b/config/crd/bases/stroom.gchq.github.io_stroomclusters.yaml
@@ -3299,6 +3299,13 @@ spec:
                         should be `true`, unless there is a need for a NodeSet to
                         be pure processing-only nodes, which cannot receive data.
                       type: boolean
+                    ingressLabels:
+                      additionalProperties:
+                        type: string
+                      description: IngressLabels is an optional map of labels to apply
+                        to the NodeSet's Ingress. These take precedence over any controller
+                        provided labels.
+                      type: object
                     livenessProbeTimings:
                       description: LivenessProbeTimings determine the parameters for
                         liveness probes. If a Pod fails successive probes, it is restarted.

--- a/controllers/stroomcluster.go
+++ b/controllers/stroomcluster.go
@@ -673,6 +673,12 @@ func (r *StroomClusterReconciler) createIngresses(ctx context.Context, stroomClu
 				ingressAnnotations[k] = v
 			}
 
+			//Apply any user-provided ingress labels
+			ingressLabels := stroomCluster.GetLabels()
+			for k, v := range nodeSet.IngressLabels {
+				ingressLabels[k] = v
+			}
+
 			//Build ingress TLS object if TLS is enabled inside the cluster
 			ingressTls := []netv1.IngressTLS{{}}
 			appPortName := AppHttpPortName
@@ -690,7 +696,7 @@ func (r *StroomClusterReconciler) createIngresses(ctx context.Context, stroomClu
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        clusterName,
 						Namespace:   stroomCluster.Namespace,
-						Labels:      stroomCluster.GetLabels(),
+						Labels:      ingressLabels,
 						Annotations: ingressAnnotations,
 					},
 					Spec: netv1.IngressSpec{
@@ -724,7 +730,7 @@ func (r *StroomClusterReconciler) createIngresses(ctx context.Context, stroomClu
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        clusterName + "-websocket",
 						Namespace:   stroomCluster.Namespace,
-						Labels:      stroomCluster.GetLabels(),
+						Labels:      ingressLabels,
 						Annotations: websocketIngressAnnotations,
 					},
 					Spec: netv1.IngressSpec{
@@ -742,11 +748,18 @@ func (r *StroomClusterReconciler) createIngresses(ctx context.Context, stroomClu
 			ingressAnnotations := map[string]string{
 				"nginx.ingress.kubernetes.io/rewrite-target":  "/stroom/noauth/datafeed",
 				"nginx.ingress.kubernetes.io/proxy-body-size": "0", // Disable client request payload size checking
+				"haproxy.router.openshift.io/rewrite-target":  "/stroom/noauth/datafeed",
 			}
 
 			// Apply any user-provided annotations
 			for k, v := range nodeSet.IngressAnnotations {
 				ingressAnnotations[k] = v
+			}
+
+			//Apply any user-provided ingress labels
+			ingressLabels := stroomCluster.GetLabels()
+			for k, v := range nodeSet.IngressLabels {
+				ingressLabels[k] = v
 			}
 
 			//Build ingress TLS object if TLS is enabled inside the cluster
@@ -765,7 +778,7 @@ func (r *StroomClusterReconciler) createIngresses(ctx context.Context, stroomClu
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        clusterName + "-datafeed",
 					Namespace:   stroomCluster.Namespace,
-					Labels:      stroomCluster.GetLabels(),
+					Labels:      ingressLabels,
 					Annotations: ingressAnnotations,
 				},
 				Spec: netv1.IngressSpec{

--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -4043,6 +4043,11 @@ spec:
                       default: true
                       description: IngressEnabled determines whether this node receives requests via the created Kubernetes Ingresses. Usually this should be `true`, unless there is a need for a NodeSet to be pure processing-only nodes, which cannot receive data.
                       type: boolean
+                    ingressLabels:
+                      additionalProperties:
+                        type: string
+                      description: IngressLabels is an optional map of labels to apply to the NodeSet's Ingress. These take precedence over any controller provided labels.
+                      type: object
                     livenessProbeTimings:
                       description: LivenessProbeTimings determine the parameters for liveness probes. If a Pod fails successive probes, it is restarted.
                       properties:


### PR DESCRIPTION
Add custom ingress labelling functionality to help with HA proxy / Openshift integration, as well as a HAProxy specific config. 