### PR TITLE
Make HTTPS related volumes optional

### DIFF
--- a/api/v1/stroomcluster_extra.go
+++ b/api/v1/stroomcluster_extra.go
@@ -11,16 +11,19 @@ type HttpsSettings struct {
 	// Boolean value controling if TLS is enabled within the cluster
 	Enabled bool `json:"enabled"`
 	// Name of the TLS secret containing the items `keystore.p12` and `truststore.p12`
-	TlsSecretName string `json:"tlsSecretName"`
+	// +kubebuilder:validation:Optional
+	TlsSecretName string `json:"tlsSecretName,omitempty"`
 	// Password of the keystore and truststore
-	TlsKeystorePasswordSecretRef SecretItem `json:"tlsKeystorePasswordSecret"`
+	// +kubebuilder:validation:Optional
+	TlsKeystorePasswordSecretRef SecretItem `json:"tlsKeystorePasswordSecret,omitempty"`
 }
 
 type IngressSettings struct {
 	// DNS name at which the application will be reached (e.g. stroom.example.com)
 	HostName string `json:"hostName"`
 	// Name of the TLS `Secret` containing the private key and server certificate for the `Ingress`
-	SecretName string `json:"secretName"`
+	// +kubebuilder:validation:Optional
+	SecretName string `json:"secretName,omitempty"`
 	// Ingress class name (e.g. nginx)
 	ClassName string `json:"className,omitempty"`
 	// Override path type for all ingress resources as `ImplementationSpecific`

--- a/config/crd/bases/stroom.gchq.github.io_stroomclusters.yaml
+++ b/config/crd/bases/stroom.gchq.github.io_stroomclusters.yaml
@@ -1925,8 +1925,6 @@ spec:
                     type: string
                 required:
                 - enabled
-                - tlsKeystorePasswordSecret
-                - tlsSecretName
                 type: object
               image:
                 properties:
@@ -1960,7 +1958,6 @@ spec:
                     type: string
                 required:
                 - hostName
-                - secretName
                 type: object
               logSender:
                 description: Configures the mechanism that posts internal audit and

--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -3309,8 +3309,6 @@ spec:
                     type: string
                 required:
                 - enabled
-                - tlsKeystorePasswordSecret
-                - tlsSecretName
                 type: object
               image:
                 properties:
@@ -3341,7 +3339,6 @@ spec:
                     type: string
                 required:
                 - hostName
-                - secretName
                 type: object
               logSender:
                 description: Configures the mechanism that posts internal audit and logging to Stroom


### PR DESCRIPTION
For #17 
Changed validation for TLS related fields to optional and change the mounting behaviour to only mount TLS volumes / secrets if HTTPS is set to enabled. 