### PR TITLE
Fix IngressEnabled: use *bool so false is not stripped by omitempty

### DIFF
--- a/api/v1/stroomcluster_nodeset.go
+++ b/api/v1/stroomcluster_nodeset.go
@@ -29,7 +29,7 @@ type NodeSet struct {
 	// IngressEnabled determines whether this node receives requests via the created Kubernetes Ingresses. Usually this
 	// should be `true`, unless there is a need for a NodeSet to be pure processing-only nodes, which cannot receive data.
 	// +kubebuilder:default:=true
-	IngressEnabled bool `json:"ingressEnabled,omitempty"`
+	IngressEnabled *bool `json:"ingressEnabled,omitempty"`
 	// IngressAnnotations is an optional map of annotations to apply to the NodeSet's Ingress. These override any
 	// default annotations provided by the controller.
 	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`

--- a/controllers/stroomcluster.go
+++ b/controllers/stroomcluster.go
@@ -669,7 +669,7 @@ func (r *StroomClusterReconciler) createIngresses(ctx context.Context, stroomClu
 		clusterName := stroomCluster.GetBaseName()
 		serviceName := stroomCluster.GetNodeSetServiceName(&nodeSet)
 
-		if !nodeSet.IngressEnabled {
+		if nodeSet.IngressEnabled != nil && !*nodeSet.IngressEnabled {
 			continue
 		}
 


### PR DESCRIPTION
Fix IngressEnabled being ignored when set to false

The field was declared as a bool with omitempty, causing false to be
stripped during serialisation (as it is the zero value). The kubebuilder
default of true would then be reapplied by the API server, making it
impossible to disable ingress creation via this field.