### PR TITLE
Fix IngressEnabled: use *bool so false is not stripped by omitempty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.so
 *.dylib
 testbin/*
+bin/setup-envtest
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.1.0
+VERSION ?= 1.1.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ endif
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.30
+ENVTEST_K8S_VERSION = 1.30.3
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -184,6 +184,7 @@ $(LOCALBIN):
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
+ENVTEST_VERSION ?= v0.0.0-20260318145839-6c9615a2a166
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
@@ -203,7 +204,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.

--- a/api/v1/stroomcluster_nodeset.go
+++ b/api/v1/stroomcluster_nodeset.go
@@ -29,7 +29,7 @@ type NodeSet struct {
 	// IngressEnabled determines whether this node receives requests via the created Kubernetes Ingresses. Usually this
 	// should be `true`, unless there is a need for a NodeSet to be pure processing-only nodes, which cannot receive data.
 	// +kubebuilder:default:=true
-	IngressEnabled bool `json:"ingressEnabled,omitempty"`
+	IngressEnabled *bool `json:"ingressEnabled,omitempty"`
 	// IngressAnnotations is an optional map of annotations to apply to the NodeSet's Ingress. These override any
 	// default annotations provided by the controller.
 	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`

--- a/charts/stroom-operator/Chart.yaml
+++ b/charts/stroom-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.0"
+appVersion: "1.1.1"

--- a/charts/stroom-operator/templates/operator.yaml
+++ b/charts/stroom-operator/templates/operator.yaml
@@ -430,7 +430,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: {{ if .Values.registry }}{{ printf "%s/" .Values.registry }}{{ end }}{{ "gradata/stroom-k8s-operator" }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+        image: {{ if .Values.registry }}{{ printf "%s/" .Values.registry }}{{ end }}{{ "gchq/stroom-k8s-operator" }}:{{ .Values.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:
           httpGet:

--- a/controllers/stroomcluster.go
+++ b/controllers/stroomcluster.go
@@ -669,7 +669,7 @@ func (r *StroomClusterReconciler) createIngresses(ctx context.Context, stroomClu
 		clusterName := stroomCluster.GetBaseName()
 		serviceName := stroomCluster.GetNodeSetServiceName(&nodeSet)
 
-		if !nodeSet.IngressEnabled {
+		if nodeSet.IngressEnabled != nil && !*nodeSet.IngressEnabled {
 			continue
 		}
 


### PR DESCRIPTION
Fix IngressEnabled being ignored when set to false

The field was declared as a bool with omitempty, causing false to be stripped during serialisation (as it is the zero value). The kubebuilder default of true would then be reapplied by the API server, making it impossible to disable ingress creation via this field. 

Changed to *bool so false is preserved as a distinct value from unset.